### PR TITLE
Fix the mocha watch for OS X: 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -143,9 +143,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
-      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ==",
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "JSONStream": {
@@ -2172,9 +2172,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "browserify": "browserify -e dist/all.min.js --standalone TsProjectSeed -o dist/all.min.js",
     "build:w": "tsc -p tsconfig.json -w",
     "lint": "tslint -c tslint.json 'src/**/*.ts'",
-    "test:tdd": "mocha --reporter min --require ts-node/register \"src/**/*.spec.ts\" --watch",
+    "test:tdd": "mocha --reporter min --require ts-node/register \"src/**/*.spec.ts\" --watch-extensions ts --watch",
     "test": "mocha --recursive --require ts-node/register \"src/**/*.spec.ts\"",
     "cover": "nyc npm test",
     "coveralls": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
@@ -53,11 +53,11 @@
   "devDependencies": {
     "@types/chai": "^4.1.7",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^12.6.2",
+    "@types/node": "^12.6.8",
     "browserify": "^16.3.0",
     "chai": "^4.2.0",
     "coveralls": "^3.0.5",
-    "mocha": "^6.1.4",
+    "mocha": "^6.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nyc": "^14.1.1",
     "rimraf": "^2.6.3",


### PR DESCRIPTION
Add --watch-extensions to the test:tdd task, versions bump: "@types/node 12.6.8", "mocha 6.2.0"

(Related issue: https://github.com/TypeStrong/ts-node/issues/266)